### PR TITLE
linebotの応答動作実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  skip_before_action :verify_authenticity_token
 end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -1,96 +1,8 @@
 class LineBotController < ApplicationController
+
   def callback
-    body = request.body.read
-    # gemのメソッドであるparse_events_from(body)でevents配列を取得する。
-    events = client.parse_events_from(body)
-    # 取得した配列を繰り返しで処理する
     events.each do |event|
-    # caseを使用して、eventの種類の条件をwhenで指定して、種類ごとに処理を行う。
-      case event
-      # eventがMessageかどうかをチェック
-      when Line::Bot::Event::Message
-      # ネストしてcaseを使用、eventのさらにタイプで分類
-        case event.type
-        # MessageType::Textかどうかをチェック
-        when Line::Bot::Event::MessageType::Text
-          case event.message["text"]
-          when "食事の記録"
-            message = {
-                        type: "text",
-                        text: "メッセージで食べたもののメニュー名を送ると記録されます。" +
-                        "送った際の時刻に食べたものとして記録されます。" +
-                        "時間指定をして記録したい場合は、サイトから実行してください。"
-                      }
-            client.reply_message(event['replyToken'], message)
-          when "便の記録"
-            message = LineBot::Messages::UnkoMessage.new.button_message
-            client.reply_message(event['replyToken'], message)
-          when "1", "2", "3"
-            puts "便の記録完了確認用"
-            stool_log = event.message["text"]
-=begin 便の記録と、状態に応じた評価値の変動未実装 issue#21で対応予定
-            Stool.create({ status: message.to_i })
-=end
-            message = {
-              type: "text",
-              text: "排便の記録が完了しました。" 
-                      }
-            client.reply_message(event['replyToken'], message)
-          when "おすすめの食事"
-            puts "おすすめの食事動作確認用"
-=begin データベース操作のコード 動作未確認 issue#22で対応予定
-            recommend_meal = Evaluation.where('evaluation >= ?', 3).order('RANDOM()').first
-            if recommend_meal.nil?
-              recommend_meal = Evaluation.where('evaluation >= ?', 1).order('RANDOM()').first
-              if recommend_meal.nil?
-                recommend_meal = "おすすめの食事はありません"
-              else
-                recommend_meal = recommend_meal.name
-              end
-            else
-              recommend_meal = recommend_meal.name
-            end
-=end
-            recommend_meal = "おすすめの食事機能は未実装です。"
-            message = {
-                        type: "text",
-                        text: recommend_meal
-                      }
-            client.reply_message(event['replyToken'], message)
-          when "避けるべき食事"
-            puts "避けるべき食事動作確認用"
-=begin データベース操作のコード 動作未確認 issue#22で対応予定
-            avert_meal = Evaluation.where('evaluation <= ?', -3).order('RANDOM()').first
-            if avert_meal.nil?
-              avert_meal = Evaluation.where('evaluation <= ?', -1).order('RANDOM()').first
-              if avert_meal.nil?
-                avert_meal = "避けるべき食事はありません"
-              else
-                avert_meal = avert_meal.name
-              end
-            else
-              avert_meal = avert_meal.name
-            end
-=end
-            avert_meal = "避けるべき食事機能は未実装です。"
-            message = {
-                        type: "text",
-                        text: avert_meal
-                      }
-            client.reply_message(event['replyToken'], message)
-          else
-            meal_log = event.message["text"]
-=begin
-            データベースへの保管を行うコードを実装予定 issue#20で対応予定
-=end
-            message = {
-                        type: "text",
-                        text: "食事の記録が完了しました。" 
-                      }
-            client.reply_message(event['replyToken'], message)
-          end
-        end
-      end
+      client.reply_message(event['replyToken'], message(event))
     end
   end
 
@@ -101,5 +13,102 @@ class LineBotController < ApplicationController
       config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
       config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
     }
+  end
+
+  def request_body
+    request_body = request.body.read
+  end
+
+  def events
+    # gemのメソッドであるparse_events_from(body)でevents配列を取得する。
+    events = client.parse_events_from(request_body)
+  end
+
+  def message(event)
+    # caseを使用して、eventの種類の条件をwhenで指定して、種類ごとに処理を行う。
+    case event
+    # eventがMessageかどうかをチェック
+    when Line::Bot::Event::Message
+    # ネストしてcaseを使用、eventのさらにタイプで分類
+      case event.type
+      # MessageType::Textかどうかをチェック
+      when Line::Bot::Event::MessageType::Text
+        case event.message["text"]
+        when "食事の記録"
+          message = {
+                      type: "text",
+                      text: "メッセージで食べたもののメニュー名を送ると記録されます。" +
+                      "送った際の時刻に食べたものとして記録されます。" +
+                      "時間指定をして記録したい場合は、サイトから実行してください。"
+                    }
+
+        when "便の記録"
+          message = LineBot::Messages::UnkoMessage.new.button_message
+
+        when "1", "2", "3"
+          puts "便の記録完了確認用"
+          stool_log = event.message["text"]
+=begin 便の記録と、状態に応じた評価値の変動未実装 issue#21で対応予定
+          Stool.create({ status: message.to_i })
+=end
+          message = {
+                      type: "text",
+                      text: "排便の記録が完了しました。" 
+                    }
+
+        when "おすすめの食事"
+          puts "おすすめの食事動作確認用"
+=begin データベース操作のコード 動作未確認 issue#22で対応予定
+          recommend_meal = Evaluation.where('evaluation >= ?', 3).order('RANDOM()').first
+          if recommend_meal.nil?
+            recommend_meal = Evaluation.where('evaluation >= ?', 1).order('RANDOM()').first
+            if recommend_meal.nil?
+              recommend_meal = "おすすめの食事はありません"
+            else
+              recommend_meal = recommend_meal.name
+            end
+          else
+            recommend_meal = recommend_meal.name
+          end
+=end
+          recommend_meal = "おすすめの食事機能は未実装です。"
+          message = {
+                      type: "text",
+                      text: recommend_meal
+                    }
+
+        when "避けるべき食事"
+          puts "避けるべき食事動作確認用"
+=begin データベース操作のコード 動作未確認 issue#22で対応予定
+          avert_meal = Evaluation.where('evaluation <= ?', -3).order('RANDOM()').first
+          if avert_meal.nil?
+            avert_meal = Evaluation.where('evaluation <= ?', -1).order('RANDOM()').first
+            if avert_meal.nil?
+              avert_meal = "避けるべき食事はありません"
+            else
+              avert_meal = avert_meal.name
+            end
+          else
+            avert_meal = avert_meal.name
+          end
+=end
+          avert_meal = "避けるべき食事機能は未実装です。"
+          message = {
+                      type: "text",
+                      text: avert_meal
+                    }
+
+        else
+          meal_log = event.message["text"]
+=begin
+          データベースへの保管を行うコードを実装予定 issue#20で対応予定
+=end
+          message = {
+                      type: "text",
+                      text: "食事の記録が完了しました。" 
+                    }
+        end
+      end
+    end
   end
 end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -1,5 +1,97 @@
 class LineBotController < ApplicationController
   def callback
+    body = request.body.read
+    # gemのメソッドであるparse_events_from(body)でevents配列を取得する。
+    events = client.parse_events_from(body)
+    # 取得した配列を繰り返しで処理する
+    events.each do |event|
+    # caseを使用して、eventの種類の条件をwhenで指定して、種類ごとに処理を行う。
+      case event
+      # eventがMessageかどうかをチェック
+      when Line::Bot::Event::Message
+      # ネストしてcaseを使用、eventのさらにタイプで分類
+        case event.type
+        # MessageType::Textかどうかをチェック
+        when Line::Bot::Event::MessageType::Text
+          case event.message["text"]
+          when "食事の記録"
+            message = {
+                        type: "text",
+                        text: "メッセージで食べたもののメニュー名を送ると記録されます。" +
+                        "送った際の時刻に食べたものとして記録されます。" +
+                        "時間指定をして記録したい場合は、サイトから実行してください。"
+                      }
+            client.reply_message(event['replyToken'], message)
+          when "便の記録"
+            message = LineBot::Messages::UnkoMessage.new.button_message
+            client.reply_message(event['replyToken'], message)
+          when "1", "2", "3"
+            puts "便の記録完了確認用"
+            stool_log = event.message["text"]
+=begin 便の記録と、状態に応じた評価値の変動未実装 issue#21で対応予定
+            Stool.create({ status: message.to_i })
+=end
+            message = {
+              type: "text",
+              text: "排便の記録が完了しました。" 
+                      }
+            client.reply_message(event['replyToken'], message)
+          when "おすすめの食事"
+            puts "おすすめの食事動作確認用"
+=begin データベース操作のコード 動作未確認 issue#22で対応予定
+            recommend_meal = Evaluation.where('evaluation >= ?', 3).order('RANDOM()').first
+            if recommend_meal.nil?
+              recommend_meal = Evaluation.where('evaluation >= ?', 1).order('RANDOM()').first
+              if recommend_meal.nil?
+                recommend_meal = "おすすめの食事はありません"
+              else
+                recommend_meal = recommend_meal.name
+              end
+            else
+              recommend_meal = recommend_meal.name
+            end
+=end
+            recommend_meal = "おすすめの食事機能は未実装です。"
+            message = {
+                        type: "text",
+                        text: recommend_meal
+                      }
+            client.reply_message(event['replyToken'], message)
+          when "避けるべき食事"
+            puts "避けるべき食事動作確認用"
+=begin データベース操作のコード 動作未確認 issue#22で対応予定
+            avert_meal = Evaluation.where('evaluation <= ?', -3).order('RANDOM()').first
+            if avert_meal.nil?
+              avert_meal = Evaluation.where('evaluation <= ?', -1).order('RANDOM()').first
+              if avert_meal.nil?
+                avert_meal = "避けるべき食事はありません"
+              else
+                avert_meal = avert_meal.name
+              end
+            else
+              avert_meal = avert_meal.name
+            end
+=end
+            avert_meal = "避けるべき食事機能は未実装です。"
+            message = {
+                        type: "text",
+                        text: avert_meal
+                      }
+            client.reply_message(event['replyToken'], message)
+          else
+            meal_log = event.message["text"]
+=begin
+            データベースへの保管を行うコードを実装予定 issue#20で対応予定
+=end
+            message = {
+                        type: "text",
+                        text: "食事の記録が完了しました。" 
+                      }
+            client.reply_message(event['replyToken'], message)
+          end
+        end
+      end
+    end
   end
 
   private

--- a/app/services/line_bot/messages/unko_message.rb
+++ b/app/services/line_bot/messages/unko_message.rb
@@ -1,0 +1,34 @@
+module LineBot
+  module Messages
+    class UnkoMessage
+      def button_message
+        {
+          "type": "template",
+          "altText": "This is a buttons select stools condition",
+          "template": {
+            "type": "buttons",
+            "title": "排便の記録",
+            "text": "選択肢から便の状態を選択してタップしてください。",
+            "actions": [
+              {
+                "type": "message",
+                "label": "1:良い",
+                "text": "1"
+              },
+              {
+                "type": "message",
+                "label": "2:普通",
+                "text": "2"
+              },
+              {
+                "type": "message",
+                "label": "3:悪い",
+                "text": "3"
+              }
+            ]
+          }
+        }
+      end
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.hosts.clear
 end


### PR DESCRIPTION
# 概要
LineBotの自動応答動作を実装しました。

なお、今回の実装はLineBotの応答機能に絞っており、
データベースを利用する部分は別issueにて対応予定です。

## 実装機能
- 食事の記録方法を確認する
- 食事メニューを記録する
- 排便の記録を始める
- 排便の記録を行う
- おすすめの食事を確認する
- 避けるべき食事を確認する

## 動作確認動画
食事記録
[![Image from Gyazo](https://i.gyazo.com/60ed93960e2514d42f37cf310947142f.gif)](https://gyazo.com/60ed93960e2514d42f37cf310947142f)
排便記録
[![Image from Gyazo](https://i.gyazo.com/7e5ac41a55130da0b8b7ac9d008a5052.gif)](https://gyazo.com/7e5ac41a55130da0b8b7ac9d008a5052)
おすすめの食事、避けるべき食事
[![Image from Gyazo](https://i.gyazo.com/18a563ed4359b8f4a202c867d06ed776.gif)](https://gyazo.com/18a563ed4359b8f4a202c867d06ed776)

## 各機能の実装内容詳細と該当コード位置
### 食事の記録方法を確認する
- app/controllers/line_bot_controller.rb 17行目〜24行目
- ユーザーが"食事の記録"と送信すると、あらかじめ設定してあるtextを返信します。

### 食事メニューを記録する
- app/controllers/line_bot_controller.rb 81行目〜90行目
- ユーザーが食事メニューをメッセージで打つと、その食事メニューを登録します。(未実装)
- 登録完了後、"食事の記録が完了しました。"とメッセージを送ります。

### 排便の記録を始める
- app/controllers/line_bot_controller.rb 25行目〜17行目
- app/services/line_bot/messages/unko_message.rb
- LineBotの機能であるボタンメッセージを利用して、ユーザーに選択肢つきのメッセージを送ります。
- ユーザーがボタンをタップすると、1~3の数字がユーザーからメッセージされます。

### 排便の記録を行う
- app/controllers/line_bot_controller.rb 28行目〜38行目
- ユーザーが数字をメッセージで送ると、それを受け取って記録します。
- データベースへの書き込み部分は未実装
- 記録完了後、"排便の記録が完了しました。"とメッセージを送ります。

### おすすめの食事を確認する、避けるべき食事を確認する
- app/controllers/line_bot_controller.rb 39行目〜80行目
- データベースから対応するデータを取得し、ユーザーにメッセージを送ります。
- データベースを操作するコードは未実装です。

close #7 
