### PR TITLE
package.jsonにbuildの記載を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "tailwindcss": "^3.4.3"
   },
   "scripts": {
-    "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"
+    "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify",
+    "build": "npm run build:css"
   }
 }


### PR DESCRIPTION
herokuのデプロイが失敗する状態を修正したい。
yarn buildが見つからないエラーが出ているので、package.jsonのscriptにbuildを追加する。