### PR TITLE
食事の記録機能完成

### DIFF
--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -1,0 +1,2 @@
+class EvaluationsController < ApplicationController
+end

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -1,0 +1,24 @@
+class MealsController < ApplicationController
+
+  # def index; end
+
+  # def new; end
+
+  def create
+    
+
+  end
+
+  # def show; end
+
+  # def edit; end
+
+  # def update; end
+
+  # def destroy; end
+
+  private
+
+  #def meal_params
+   # params.require(:).permit()
+end

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -5,8 +5,23 @@ class MealsController < ApplicationController
   # def new; end
 
   def create
-    
-
+    user_id = current_user.id
+    meal = Meal.find_by(meal_name: params[:meal_name])
+    if meal.present?
+      meal_id = meal.id
+    else
+      meal = Meal.new(meal_name: params[:meal_name], user_id: user_id)
+      meal.save
+      meal_id = meal.id
+    end
+    evaluation = Evaluation.new(user_id: user_id, meal_id: meal_id, eated_at: params[:eated_at])
+    if evaluation.save
+      flash[:notice] = '食事を記録しました'
+      redirect_to user_path(current_user)
+    else
+      flash.now[:danger] = '食事の記録に失敗しました'
+      render("user/show")
+    end
   end
 
   # def show; end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -18,6 +18,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in(:user, @profile)
     end
     flash[:notice] = "ログインしました"
-    redirect_to expendable_items_path #自分のルーティングに変更すること
+    redirect_to user_path(current_user) #自分のルーティングに変更すること
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+
+  def show; end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
 
   def show; end
 end

--- a/app/helpers/evaluations_helper.rb
+++ b/app/helpers/evaluations_helper.rb
@@ -1,0 +1,2 @@
+module EvaluationsHelper
+end

--- a/app/helpers/meals_helper.rb
+++ b/app/helpers/meals_helper.rb
@@ -1,0 +1,2 @@
+module MealsHelper
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="flex-none">
     <ul class="menu menu-horizontal px-1">
-      <li class="bg-green-500 text-white rounded-lg"><a>LINE連携ログイン</a></li>
+      <li class="bg-green-500 text-white rounded-lg"><%= button_to 'LINE連携ログイン', omniauth_authorize_path(:user, :line), data: { turbo: false } %></li>
     </ul>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,13 @@
+<%= form_with url: meals_path do |f| %>
+  <div>
+    <%= f.label :meal_name %>
+    <%= f.text_field :meal_name %>
+  </div>
+  <div class="form-group">
+    <%= f.label :eated_at %>
+    <%= f.datetime_field :eated_at %>
+  </div>
+  <div>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,7 +5,7 @@
   </div>
   <div class="form-group">
     <%= f.label :eated_at %>
-    <%= f.datetime_field :eated_at %>
+    <%= f.datetime_field :eated_at, value: Time.current %>
   </div>
   <div>
     <%= f.submit %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module Myapp
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,6 @@ Rails.application.routes.draw do
   }
   root 'static_pages#index'
   post 'callback' => 'line_bot#callback'
+  resources :users, only: %i[show]
+  resources :meals, only: %i[create]
 end

--- a/test/controllers/evaluations_controller_test.rb
+++ b/test/controllers/evaluations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EvaluationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/meals_controller_test.rb
+++ b/test/controllers/meals_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MealsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
食事の記録機能をマイページのフォームから入力できるようにしました。


## 実装内容
実装した機能の動線順で記載していきます。
- トップページのLINE連携ログインボタンを有効化
- ログイン後のリダイレクト先をマイページに設定
- マイページのviewを作成し、食事記録フォームを設置
- マイページにログイン認証を設定
- 記録フォームの日時入力の初期設定に東京の現在時刻が入るように設定
- 食事記録の機能をMealモデルに担わせることとし、meals_controllerのcreateアクションで実行