### PR TITLE
マイページのレイアウトを作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,5 +10,18 @@ class UsersController < ApplicationController
     if @avert_meals.nil?
       @avert_meals = current_user.meals.where('score >= ?', 1)
     end
+
+    meal_log_index = current_user.eatings.includes(:meal)
+    stool_log_index = current_user.stools
+    meal_log_index = meal_log_index.to_a
+    stool_log_index = stool_log_index.to_a
+    @log_index = meal_log_index.concat(stool_log_index)
+    @log_index = @log_index.sort_by do |log|
+      if log.is_a?(Eating)
+        log.eated_at
+      elsif log.is_a?(Stool)
+        log.created_at
+      end
+    end
   end
 end

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar bg-base-100">
   <div class="flex-1">
-    <a class="btn btn-ghost text-xl">Puri.log</a>
+    <%= link_to 'Puri.log', root_path, class: "btn btn-ghost text-xl" %>
   </div>
   <div class="flex-none">
     <ul class="menu menu-horizontal px-1">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,11 +1,11 @@
 <div class="navbar bg-base-100">
   <div class="flex-1">
-    <a class="btn btn-ghost text-xl">daisyUI</a>
+    <%= link_to 'Puri.log', root_path, class: "btn btn-ghost text-xl" %>
   </div>
   <div class="flex-none">
     <ul class="menu menu-horizontal px-1">
-      <li><a>マイページ</a></li>
-      <li><a>ログアウト</a></li>
+      <li><%= link_to 'マイページ', user_path(current_user) %></li>
+      <li><%= button_to 'ログアウト', destroy_user_session_path, method: :delete %></li>
     </ul>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,34 +1,125 @@
-<%= form_with url: meals_path do |f| %>
-  <div>
-    <%= f.label :meal_name %>
-    <%= f.text_field :meal_name %>
+<div class="bg-base-200 space-y-20">
+  <div class="md:flex justify-center items-center gap-4 space-y-4 mx-auto max-w-screen-md">
+    <div class="card w-96 bg-base-100 shadow-xl mx-auto">
+      <div class="card-body">
+        <h2 class="card-title">食事の記録</h2>
+        <%= form_with url: meals_path, class: "w-full max-w-md" do |f| %>
+          <div class="md:flex md:items-center mb-6">
+            <div class="md:w-1/3">
+              <%= f.label :meal_name, "食事名", class: "block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" %>
+            </div>
+            <div class="md:w-2/3">
+              <%= f.text_field :meal_name, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500" %>
+            </div>
+          </div>
+          <div class="md:flex md:items-center mb-6">
+            <div class="md:w-1/3">
+              <%= f.label :eated_at, "食べた時間", class: "block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" %>
+            </div>
+            <div class="md:w-2/3">
+              <%= f.datetime_field :eated_at, value: Time.current.strftime('%Y-%m-%dT'), class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500" %>
+            </div>
+          </div>
+          <div class="md:flex md:items-center">
+            <div class="md:w-1/3"></div>
+            <div class="md:w-2/3">
+              <%= f.submit "記録する", class: "btn btn-ghost shadow bg-base-300 hover:bg-base-400 focus:shadow-outline focus:outline-none font-bold py-2 px-4 rounded" %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div class="card w-96 bg-base-100 shadow-xl mx-auto">
+      <div class="card-body">
+        <h2 class="card-title">排便の記録</h2>
+        <%= form_with url: stools_path, class: "w-full max-w-md" do |f| %>
+          <div class="md:flex md:items-center mb-6">
+            <div class="md:w-1/3">
+              <%= f.label :condition, "便の状態", class: "block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" %>
+            </div>
+            <div class="md:w-2/3">
+              <%= f.select :condition, [["0.良い", 0], ["1.普通", 1], ["2.悪い", 2]], {include_blank: "選択して下さい"}, class: "bg-gray-200 border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500" %>
+            </div>
+          </div>
+          <div class="md:flex md:items-center mb-6">
+            <div class="md:w-1/3">
+              <%= f.label :created_at, "出した日時", class: "block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" %>
+            </div>
+            <div class="md:w-2/3">
+              <%= f.datetime_field :created_at, value: Time.current.strftime('%Y-%m-%dT'), class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500" %>
+            </div>
+          </div>
+          <div class="md:flex md:items-center">
+            <div class="md:w-1/3"></div>
+            <div class="md:w-2/3">
+              <%= f.submit "記録する", class: "btn btn-ghost shadow bg-base-300 hover:bg-base-400 focus:shadow-outline focus:outline-none font-bold py-2 px-4 rounded" %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
   </div>
-  <div class="form-group">
-    <%= f.label :eated_at %>
-    <%= f.datetime_field :eated_at, value: Time.current %>
+  <div class="md:flex justify-center items-center gap-4 space-y-4 mx-auto max-w-screen-md">
+    <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
+      <div class="card-body">
+        <h2 class="card-title">おすすめの食事</h2>
+        <div class="max-h-72 overflow-auto">
+          <% @recommend_meals.each do |recommend_meal| %>
+            <p><%= recommend_meal.meal_name %></p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
+      <div class="card-body">
+        <h2 class="card-title">避けるべき食事</h2>
+        <div class="max-h-72 overflow-auto">
+          <% @avert_meals.each do |avert_meal| %>
+            <p><%= avert_meal.meal_name %></p>
+          <% end %>
+        </div>
+      </div>
+    </div>
   </div>
-  <div>
-    <%= f.submit %>
+  <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
+    <div class="card-body">
+      <h2 class="card-title">記録履歴一覧</h2>
+      <div class="max-h-72 overflow-auto">
+        <table class="table table-xs table-pin-rows table-pin-cols">
+          <thead>
+            <tr>
+              <th></th> 
+              <td>食事名</td> 
+              <td>便の状態</td> 
+              <td>記録日時</td> 
+              <th></th> 
+            </tr>
+          </thead> 
+          <% @log_index.each do |log| %>
+            <% if log.is_a?(Eating) %>
+              <tbody>
+                <tr>
+                  <th></th>
+                  <td><%= log.meal.meal_name %></td>
+                  <td>-</td> 
+                  <td><%= log.eated_at %></td>
+                  <th></th>
+                </tr>
+              </tbody> 
+            <% elsif log.is_a?(Stool) %>
+              <tbody>
+                <tr>
+                  <th></th>
+                  <td>-</td> 
+                  <td><%= log.condition %></td>
+                  <td><%= log.created_at %></td> 
+                  <th></th>
+                </tr>
+              </tbody> 
+            <% end %>
+          <% end %>
+        </table>
+      </div>
+    </div>
   </div>
-<% end %>
-<%= form_with url: stools_path do |f| %>
-  <div>
-    <%= f.label :condition %>
-    <%= f.select :condition,  [["0.良い", 0], ["1.普通", 1], ["2.悪い", 2]], include_blank: "選択して下さい" %>
-  </div>
-  <div class="form-group">
-    <%= f.label :created_at %>
-    <%= f.datetime_field :created_at, value: Time.current %>
-  </div>
-  <div>
-    <%= f.submit %>
-  </div>
-<% end %>
-<p>おすすめの食事</p>
-<% @recommend_meals.each do |recommend_meal| %>
-  <p><%= recommend_meal.meal_name %></p>
-<% end %>
-<p>避けるべき食事</p>
-<% @avert_meals.each do |avert_meal| %>
-  <p><%= avert_meal.meal_name %></p>
-<% end %>
+</div>


### PR DESCRIPTION
# 概要
マイページのレイアウトを調整しました。

## 変更内容
- ヘッダーとページの背景色をトップページに倣って修正
- フォームの見た目を整えた。
- 記録履歴一覧表示を作成
- 各要素をcardコンポーネントに配置
- flex配置を適用させて画面サイズに応じた配置にした。