### PR TITLE
データベースをmysqlに変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.3.0
 
 ENV TZ Asia/Tokyo
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs && apt-get install -y vim
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs && apt-get install -y vim default-mysql-client
 
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - \
   && wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ gem "rails", "~> 7.1.3", ">= 7.1.3.2"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 
-# Use postgresql as the database for Active Record
-gem "pg", "~> 1.1"
+gem "mysql2"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,7 @@ GEM
     msgpack (1.7.2)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
+    mysql2 (0.5.6)
     net-http (0.4.1)
       uri
     net-imap (0.4.10)
@@ -188,7 +189,6 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
-    pg (1.5.6)
     psych (5.1.2)
       stringio
     public_suffix (5.0.4)
@@ -304,9 +304,9 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   line-bot-api
+  mysql2
   omniauth-line
   omniauth-rails_csrf_protection
-  pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
   selenium-webdriver

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -102,7 +102,7 @@
                   <th></th>
                   <td><%= log.meal.meal_name %></td>
                   <td>-</td> 
-                  <td><%= log.eated_at %></td>
+                  <td><%= log.eated_at.strftime('%Y-%m-%d %H:%M') %></td>
                   <th></th>
                 </tr>
               </tbody> 
@@ -111,8 +111,16 @@
                 <tr>
                   <th></th>
                   <td>-</td> 
-                  <td><%= log.condition %></td>
-                  <td><%= log.created_at %></td> 
+                  <% if log.condition == "good" %>
+                    <td>良い</td>
+                  <% elsif log.condition == "normal" %>
+                    <td>普通</td>
+                  <% elsif log.condition == "bad" %>
+                    <td>悪い</td>
+                  <% else %>
+                    <td><%= log.condition %></td>
+                  <% end %>
+                  <td><%= log.created_at.strftime('%Y-%m-%d %H:%M') %></td> 
                   <th></th>
                 </tr>
               </tbody> 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,11 +1,18 @@
 services:
   db:
-    image: postgres
+    image: mysql:8.0
     environment:
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: password
     volumes:
-      - postgres_volume:/var/lib/postgresql/data
+      - mysql_data:/var/lib/mysql
+    ports:
+      - 3307:3306
+    healthcheck:
+      test: mysqladmin ping -h 127.0.0.1 -uroot -ppassword
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
   web:
     build:
       context: .
@@ -21,5 +28,5 @@ services:
     depends_on:
       - db
 volumes:
-  postgres_volume:
+  mysql_data:
   node_modules:

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,8 +1,8 @@
 default: &default
-  adapter: postgresql
-  encoding: unicode
+  adapter: mysql2
+  encoding: utf8mb4
   host: db
-  username: postgres
+  username: root
   password: password
   pool: 5
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_04_20_083319) do
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
-  create_table "eatings", force: :cascade do |t|
+  create_table "eatings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "meal_id"
     t.datetime "eated_at"
@@ -24,7 +21,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_20_083319) do
     t.index ["user_id"], name: "index_eatings_on_user_id"
   end
 
-  create_table "meals", force: :cascade do |t|
+  create_table "meals", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "meal_name"
     t.bigint "user_id"
     t.datetime "created_at", null: false
@@ -33,7 +30,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_20_083319) do
     t.index ["user_id"], name: "index_meals_on_user_id"
   end
 
-  create_table "stools", force: :cascade do |t|
+  create_table "stools", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "condition", default: 0, null: false
     t.datetime "created_at", null: false
@@ -41,7 +38,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_20_083319) do
     t.index ["user_id"], name: "index_stools_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"


### PR DESCRIPTION
# 概要
デプロイに向けたデータベースの変更(postgresql→mysql)

## 変更内容
- docker composeのデータベース設定をmysqlに変更
- 既存のデータベースを削除し、mysqlで新規作成
- マイページの記録一覧表示部の英語表記を日本語表記に変更